### PR TITLE
Flexible steps syntax and minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .DS_Store
+.test

--- a/go.sum
+++ b/go.sum
@@ -146,7 +146,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -200,7 +199,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -222,7 +220,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/kubedog.go
+++ b/kubedog.go
@@ -15,12 +15,12 @@ limitations under the License.
 package kubedog
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/cucumber/godog"
 	aws "github.com/keikoproj/kubedog/pkg/aws"
 	kube "github.com/keikoproj/kubedog/pkg/kubernetes"
+	log "github.com/sirupsen/logrus"
 )
 
 type Test struct {
@@ -40,32 +40,27 @@ Run contains the steps definition, should be called in the InitializeScenario fu
 Check https://github.com/keikoproj/kubedog/blob/master/docs/syntax.md for steps syntax details.
 */
 func (kdt *Test) Run() {
-	// TODO: define default suite hooks if any, check that the suite context was set
-
 	if kdt.scenarioContext == nil {
-		fmt.Println("FATAL: kubedog.Test.scenarioContext was not set, use kubedog.Test.InitScenario")
+		log.Fatalln("kubedog.Test.scenarioContext was not set, use kubedog.Test.InitScenario")
 		os.Exit(testFailedStatus)
 	}
 
-	// TODO: define default scenario hooks if any
-	// TODO: define default step hooks if any
-
 	// Kubernetes related steps
 	kdt.scenarioContext.Step(`^a Kubernetes cluster$`, kdt.KubeContext.AKubernetesCluster)
-	kdt.scenarioContext.Step(`^I (create|submit|delete) the resource ([^"]*)$`, kdt.KubeContext.ResourceOperation)
-	kdt.scenarioContext.Step(`^the resource ([^"]*) should be (created|deleted)$`, kdt.KubeContext.ResourceShouldBe)
-	kdt.scenarioContext.Step(`^the resource ([^"]*) should converge to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
-	kdt.scenarioContext.Step(`^the resource ([^"]*) converge to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
-	kdt.scenarioContext.Step(`^the resource ([^"]*) condition ([^"]*) should be (true|false)$`, kdt.KubeContext.ResourceConditionShouldBe)
-	kdt.scenarioContext.Step(`^I update a resource ([^"]*) with ([^"]*) set to ([^"]*)$`, kdt.KubeContext.UpdateResourceWithField)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource ([^"]*)$`, kdt.KubeContext.ResourceOperation)
+	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should be (created|deleted)$`, kdt.KubeContext.ResourceShouldBe)
+	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) converged to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
+	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should converge to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
+	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) condition ([^"]*) should be (true|false)$`, kdt.KubeContext.ResourceConditionShouldBe)
+	kdt.scenarioContext.Step(`^(?:I )?update (?:a )?resource ([^"]*) with ([^"]*) set to ([^"]*)$`, kdt.KubeContext.UpdateResourceWithField)
 	kdt.scenarioContext.Step(`^(\d+) node\(s\) with selector ([^"]*) should be (found|ready)$`, kdt.KubeContext.NodesWithSelectorShouldBe)
-	kdt.scenarioContext.Step(`^deployment ([^"]*) is in namespace ([^"]*)$`, kdt.KubeContext.DeploymentInNamespace)
-	kdt.scenarioContext.Step(`^scale deployment ([^"]*) in namespace ([^"]*) to (\d+)$`, kdt.KubeContext.ScaleDeployment)
+	kdt.scenarioContext.Step(`^(?:the )?deployment ([^"]*) is in namespace ([^"]*)$`, kdt.KubeContext.DeploymentInNamespace)
+	kdt.scenarioContext.Step(`^(?:I )?scale (?:the )?deployment ([^"]*) in namespace ([^"]*) to (\d+)$`, kdt.KubeContext.ScaleDeployment)
 	// AWS related steps
 	kdt.scenarioContext.Step(`^valid AWS Credentials$`, kdt.AwsContext.GetAWSCredsAndClients)
 	kdt.scenarioContext.Step(`^an Auto Scaling Group named ([^"]*)$`, kdt.AwsContext.AnASGNamed)
-	kdt.scenarioContext.Step(`^I update the current Auto Scaling Group with ([^"]*) set to ([^"]*)$`, kdt.AwsContext.UpdateFieldOfCurrentASG)
-	kdt.scenarioContext.Step(`the current Auto Scaling Group is scaled to \(min, max\) = \((\d+), (\d+)\)$`, kdt.AwsContext.ScaleCurrentASG)
+	kdt.scenarioContext.Step(`^(?:I )?update (?:the )current Auto Scaling Group with ([^"]*) set to ([^"]*)$`, kdt.AwsContext.UpdateFieldOfCurrentASG)
+	kdt.scenarioContext.Step(`(?:the )?current Auto Scaling Group (?:is )scaled to \(min, max\) = \((\d+), (\d+)\)$`, kdt.AwsContext.ScaleCurrentASG)
 }
 
 /*

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -28,7 +28,6 @@ import (
 )
 
 type Client struct {
-	// TODO: support multiple ASG
 	ASClient         autoscalingiface.AutoScalingAPI
 	AsgName          string
 	LaunchConfigName string

--- a/pkg/kubernetes/kube_test.go
+++ b/pkg/kubernetes/kube_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -75,7 +75,6 @@ func TestPositiveNodesWithSelectorShouldBe(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	err = kc.NodesWithSelectorShouldBe(1, testFoundSelector, NodeStateFound)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	// TODO: negative test
 }
 
 func TestPostitiveResourceOperation(t *testing.T) {
@@ -104,12 +103,10 @@ func TestPostitiveResourceOperation(t *testing.T) {
 		FilesPath:          "../../test/templates",
 	}
 
-	// TODO: test resource already created and already deleted
 	err = kc.ResourceOperation(OperationCreate, fileName)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	err = kc.ResourceOperation(OperationDelete, fileName)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	// TODO: negative test
 }
 
 func TestPostitiveResourceShouldBe(t *testing.T) {
@@ -157,7 +154,6 @@ func TestPostitiveResourceShouldBe(t *testing.T) {
 
 	err = kc.ResourceShouldBe(fileName, ResourceStateDeleted)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	// TODO: negative test
 }
 
 func TestPostitiveResourceShouldConvergeToSelector(t *testing.T) {
@@ -196,7 +192,6 @@ func TestPostitiveResourceShouldConvergeToSelector(t *testing.T) {
 
 	err = kc.ResourceShouldConvergeToSelector(fileName, selector)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	// TODO: negative test
 }
 
 func TestPostitiveResourceConditionShouldBe(t *testing.T) {
@@ -236,7 +231,6 @@ func TestPostitiveResourceConditionShouldBe(t *testing.T) {
 
 	err = kc.ResourceConditionShouldBe(fileName, testConditionType, testConditionStatus)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	// TODO: negative test
 }
 
 func TestPostitiveUpdateResourceWithField(t *testing.T) {
@@ -286,7 +280,6 @@ func TestPostitiveUpdateResourceWithField(t *testing.T) {
 	expectedLabelValue, found, err := unstructured.NestedString(testResource.UnstructuredContent(), "metadata", "labels", "testUpdateKey")
 	g.Expect(found).To(gomega.BeTrue())
 	g.Expect(expectedLabelValue).To(gomega.Equal(testUpdateValue))
-	// TODO: negative test
 }
 
 func TestDeploymentInNamespace(t *testing.T) {


### PR DESCRIPTION
Closes #34 and #30 

- Using non-capturing groups to add flexibility around the steps syntax
- Moved TODO comments to issues
- Checking for `nil` interfaces to better handle `invalid memory address or nil pointer dereference`
- Common getters for resources' paths
- Checking errors previously ignored

**Tests**: implemented and successfully ran the following `*.feature` file using this changes:

``` gherkin
Feature: Kubedog

    Scenario: Test

        Given valid AWS Credentials
        And a Kubernetes cluster
        Then deployment cluster-autoscaler is in namespace addon-cluster-autoscaler-ns
        * the deployment cluster-autoscaler is in namespace addon-cluster-autoscaler-ns
        But scale deployment workflow-controller in namespace addon-active-monitor-ns to 0
        * I scale the deployment workflow-controller in namespace addon-active-monitor-ns to 1
        Given I create the resource ig.yaml
        Then the resource ig.yaml should be created
        * resource ig.yaml should be created
        Given an Auto Scaling Group named agaro-arktika-bdd-instance-manager-kubedog-test
        But current Auto Scaling Group is scaled to (min, max) = (0, 1)
        * the current Auto Scaling Group is scaled to (min, max) = (0, 1)
        Then 1 node(s) with selector eks.k8s.io/instancegroup=kubedog-test should be found

        When I submit the resource namespace.yaml
        * create resource pod.yaml
        Then the resource pod.yaml should be created
        * resource pod.yaml condition Ready should be true
        * the resource pod.yaml condition Ready should be true
        * update resource pod.yaml with Labels set to test-key=test-value
        * I update a resource pod.yaml with Labels set to test-key=test-value
        And 1 node(s) with selector eks.k8s.io/instancegroup=kubedog-test should be ready
        And the resource pod.yaml should converge to selector status.phase=Running
        * resource pod.yaml converged to selector status.phase=Running
        When I delete the resource namespace.yaml
        Then the resource pod.yaml should be deleted
        * update current Auto Scaling Group with DesiredCapacity set to 1
        * I update the current Auto Scaling Group with DesiredCapacity set to 1
        And 1 node(s) with selector eks.k8s.io/instancegroup=kubedog-test should be found
```