### PR TITLE
Support RBAC functional testing

### DIFF
--- a/kubedog.go
+++ b/kubedog.go
@@ -55,8 +55,9 @@ func (kdt *Test) Run() {
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) condition ([^"]*) should be (true|false)$`, kdt.KubeContext.ResourceConditionShouldBe)
 	kdt.scenarioContext.Step(`^(?:I )?update (?:a )?resource ([^"]*) with ([^"]*) set to ([^"]*)$`, kdt.KubeContext.UpdateResourceWithField)
 	kdt.scenarioContext.Step(`^(\d+) node\(s\) with selector ([^"]*) should be (found|ready)$`, kdt.KubeContext.NodesWithSelectorShouldBe)
-	kdt.scenarioContext.Step(`^(?:the )?(deployment|hpa|horizontalpodautoscaler|service|pdb|poddisruptionbudget) ([^"]*) is in namespace ([^"]*)$`, kdt.KubeContext.ResourceInNamespace)
+	kdt.scenarioContext.Step(`^(?:the )?(deployment|hpa|horizontalpodautoscaler|service|pdb|poddisruptionbudget|sa|serviceaccount) ([^"]*) is in namespace ([^"]*)$`, kdt.KubeContext.ResourceInNamespace)
 	kdt.scenarioContext.Step(`^(?:I )?scale (?:the )?deployment ([^"]*) in namespace ([^"]*) to (\d+)$`, kdt.KubeContext.ScaleDeployment)
+	kdt.scenarioContext.Step(`^(?:the )?(clusterrole|clusterrolebinding) with name ([^"]*) should be found`, kdt.KubeContext.ClusterRbacIsFound)
 	// AWS related steps
 	kdt.scenarioContext.Step(`^valid AWS Credentials$`, kdt.AwsContext.GetAWSCredsAndClients)
 	kdt.scenarioContext.Step(`^an Auto Scaling Group named ([^"]*)$`, kdt.AwsContext.AnASGNamed)

--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -619,3 +619,48 @@ func (kc *Client) getResourcePath(resourceFileName string) string {
 	templatesPath := kc.getTemplatesPath()
 	return filepath.Join(templatesPath, resourceFileName)
 }
+
+/*
+ServiceAccountInNamespace check if service account is created in the related namespace
+*/
+func (kc *Client) ServiceAccountInNamespace(name, ns string) error {
+	if kc.KubeInterface == nil {
+		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
+	}
+	_, err := kc.KubeInterface.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+ClusterRoleIsFound check if needed clusterrole has been created.
+ */
+
+func (kc *Client) ClusterRoleIsFound(name string) error {
+	if kc.KubeInterface == nil {
+		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
+	}
+	_, err := kc.KubeInterface.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+ClusterRoleBindingIsFound check if cluster role binding is present.
+*/
+
+
+func (kc *Client) ClusterRoleBindingIsFound(name string) error {
+	if kc.KubeInterface == nil {
+		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
+	}
+	_, err := kc.KubeInterface.RbacV1().ClusterRoleBindings().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -572,6 +572,8 @@ func (kc *Client) ResourceInNamespace(resource, name, ns string) error {
 
 	case "pdb", "poddisruptionbudget":
 		_, err = kc.KubeInterface.PolicyV1beta1().PodDisruptionBudgets(ns).Get(name, metav1.GetOptions{})
+	case "sa", "serviceaccount":
+		_, err = kc.KubeInterface.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 
 	default:
 		return errors.Errorf("Invalid resource type")
@@ -621,44 +623,24 @@ func (kc *Client) getResourcePath(resourceFileName string) string {
 }
 
 /*
-ServiceAccountInNamespace check if service account is created in the related namespace
-*/
-func (kc *Client) ServiceAccountInNamespace(name, ns string) error {
-	if kc.KubeInterface == nil {
-		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
-	}
-	_, err := kc.KubeInterface.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-/*
-ClusterRoleIsFound check if needed clusterrole has been created.
- */
-
-func (kc *Client) ClusterRoleIsFound(name string) error {
-	if kc.KubeInterface == nil {
-		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
-	}
-	_, err := kc.KubeInterface.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-/*
-ClusterRoleBindingIsFound check if cluster role binding is present.
+Cluster scoped role and bindings are found.
 */
 
-
-func (kc *Client) ClusterRoleBindingIsFound(name string) error {
+func (kc *Client) ClusterRbacIsFound(resource, name string) error {
+	var err error
 	if kc.KubeInterface == nil {
 		return errors.Errorf("'Client.KubeInterface' is nil. 'AKubernetesCluster' sets this interface, try calling it before using this method")
 	}
-	_, err := kc.KubeInterface.RbacV1().ClusterRoleBindings().Get(name, metav1.GetOptions{})
+
+	switch resource{
+	case "clusterrole":
+		_, err = kc.KubeInterface.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
+	case "clusterrolebinding":
+		_, err = kc.KubeInterface.RbacV1().ClusterRoleBindings().Get(name, metav1.GetOptions{})
+	default:
+		return errors.Errorf("Invalid resource type")
+	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/kubernetes/kube_test.go
+++ b/pkg/kubernetes/kube_test.go
@@ -376,6 +376,10 @@ func TestResourceInNamespace(t *testing.T) {
 			resource: "poddisruptionbudget",
 			name:     "test_pdb",
 		},
+		{
+			resource: "serviceaccount",
+			name:     "mock_service_account",
+		},
 	}
 
 	kc := Client{
@@ -412,7 +416,7 @@ func TestResourceInNamespace(t *testing.T) {
 				_, _ = kc.KubeInterface.PolicyV1beta1().PodDisruptionBudgets(namespace).Create(&policy.PodDisruptionBudget{
 					ObjectMeta: meta,
 				})
-			case "sa":
+			case "serviceaccount":
 				_, _ = kc.KubeInterface.CoreV1().ServiceAccounts(namespace).Create(&v1.ServiceAccount{
 					ObjectMeta: meta,
 				})

--- a/pkg/kubernetes/kube_test.go
+++ b/pkg/kubernetes/kube_test.go
@@ -16,6 +16,7 @@ package kube
 
 import (
 	"io/ioutil"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"path/filepath"
 	"testing"
 
@@ -411,6 +412,10 @@ func TestResourceInNamespace(t *testing.T) {
 				_, _ = kc.KubeInterface.PolicyV1beta1().PodDisruptionBudgets(namespace).Create(&policy.PodDisruptionBudget{
 					ObjectMeta: meta,
 				})
+			case "sa":
+				_, _ = kc.KubeInterface.CoreV1().ServiceAccounts(namespace).Create(&v1.ServiceAccount{
+					ObjectMeta: meta,
+				})
 			}
 			err = kc.ResourceInNamespace(tt.resource, tt.name, namespace)
 			g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -493,5 +498,54 @@ func addLabel(in *unstructured.Unstructured, key, value string) {
 	err := unstructured.SetNestedMap(in.Object, labels, "metadata", "labels")
 	if err != nil {
 		log.Errorf("Failed adding label %v=%v to the resource %v: %v", key, value, in.GetName(), err)
+	}
+}
+
+func TestClusterRoleAndBindingIsFound(t *testing.T) {
+	var (
+		err            error
+		g              = gomega.NewWithT(t)
+		fakeKubeClient = fake.NewSimpleClientset()
+	)
+
+	kc := Client{
+		KubeInterface: fakeKubeClient,
+	}
+
+	tests := []struct {
+		resource string
+		name     string
+	}{
+		{
+			resource: "clusterrole",
+			name: "mock_cluster_role",
+		},
+		{
+			resource: "clusterrolebinding",
+			name: "mock_cluster_role_binding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.resource, func(t *testing.T) {
+			meta := metav1.ObjectMeta{
+				Name: tt.name,
+			}
+
+			switch tt.resource {
+			case "clusterrole":
+				_, _ = kc.KubeInterface.RbacV1().ClusterRoles().Create(&rbacv1.ClusterRole{
+
+					ObjectMeta: meta,
+				})
+			case "clusterrolebinding":
+				_, _ = kc.KubeInterface.RbacV1().ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
+
+					ObjectMeta: meta,
+				})
+			}
+			err = kc.ClusterRbacIsFound(tt.resource, tt.name)
+			g.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
 	}
 }


### PR DESCRIPTION
Added support for testing serviceaccount, clusterrole and clusterrolebindings. Our add-ons need all of these to be present in order to have a successful deployments. It makes sense to add these as part of functional tests checks as well.