### PR TITLE
fix: only perform templating if args not nil

### DIFF
--- a/internal/utilities/util.go
+++ b/internal/utilities/util.go
@@ -117,18 +117,25 @@ func GetMultipleResourcesFromYaml(path string, dc discovery.DiscoveryInterface, 
 	}
 	return resourceList, err
 }
+
 func GetResourceFromString(resourceString string, dc discovery.DiscoveryInterface, args interface{}) (K8sUnstructuredResource, error) {
 	resource := &unstructured.Unstructured{}
-
-	template, err := template.New("Resource").Parse(resourceString)
-	if err != nil {
-		return K8sUnstructuredResource{nil, resource}, err
-	}
 	var renderBuffer bytes.Buffer
-	err = template.Execute(&renderBuffer, &args)
-	if err != nil {
-		return K8sUnstructuredResource{nil, resource}, err
+
+	if args != nil {
+		template, err := template.New("Resource").Parse(resourceString)
+		if err != nil {
+			return K8sUnstructuredResource{nil, resource}, err
+		}
+
+		err = template.Execute(&renderBuffer, &args)
+		if err != nil {
+			return K8sUnstructuredResource{nil, resource}, err
+		}
+	} else {
+		renderBuffer.WriteString(resourceString)
 	}
+
 	dec := serializer.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, gvk, err := dec.Decode(renderBuffer.Bytes(), nil, resource)
 	if err != nil {

--- a/test/templates/analysis-template.yaml
+++ b/test/templates/analysis-template.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  labels:
+    env: dev
+  name: args-test
+spec:
+  args:
+  - name: namespace
+  - name: stable-hash
+  - name: canary-hash
+  - name: prometheus-port
+  - name: cpu-utilization-limit-perc
+  - name: initial-delay
+    value: 1m
+  - name: count
+    value: "10"
+  - name: interval
+    value: 60s
+  - name: failure-limit
+    value: "1"
+  - name: inconclusive-limit
+    value: "1"
+  metrics:
+  - count: '{{args.count}}'
+    failureLimit: '{{args.failure-limit}}'
+    inconclusiveLimit: '{{args.inconclusive-limit}}'
+    initialDelay: '{{args.initial-delay}}'
+    interval: '{{args.interval}}'
+    name: cpu-utilization
+    provider:
+      prometheus:
+        address: http://prometheus.addon-metricset-ns.svc.cluster.local:{{args.prometheus-port}}
+        query: (quantile(0.5, quantile_over_time(0.5, namespace_pod_cpu_utilization{namespace="{{args.namespace}}",
+          pod=~".*-{{args.canary-hash}}-.*"}[11m])))
+    successCondition: result[0] <= {{args.cpu-utilization-limit-perc}}


### PR DESCRIPTION
Partially addresses #60 

While this does not address the case of using `{{args.property}}` syntax with templating, it does provide a solution to not use templating when it's not needed, which helps with issue #60.

Signed-off-by: Daniel Helfand <helfand.4@gmail.com>