### PR TITLE
fix: tighten regex for filepath args in steps

### DIFF
--- a/kubedog.go
+++ b/kubedog.go
@@ -48,10 +48,10 @@ func (kdt *Test) Run() {
 
 	// Kubernetes related steps
 	kdt.scenarioContext.Step(`^a Kubernetes cluster$`, kdt.KubeContext.AKubernetesCluster)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource ([^"]*)$`, kdt.KubeContext.ResourceOperation)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource ([^"]*) in (?:the )?([^"]*) namespace`, kdt.KubeContext.ResourceOperationInNamespace)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^"]*)$`, kdt.KubeContext.MultiResourceOperation)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^"]*) in (?:the )?([^"]*) namespace`, kdt.KubeContext.MultiResourceOperationInNamespace)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource (\S+)$`, kdt.KubeContext.ResourceOperation)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.ResourceOperationInNamespace)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in (\S+)$`, kdt.KubeContext.MultiResourceOperation)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.MultiResourceOperationInNamespace)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should be (created|deleted)$`, kdt.KubeContext.ResourceShouldBe)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) converged to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should converge to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)


### PR DESCRIPTION
#62 added the following steps to kubedog to allow resources without namespaces defined in manifests to be created:

```go
kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource ([^"]*) in (?:the )?([^"]*) namespace`, kdt.KubeContext.ResourceOperationInNamespace)

kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^"]*) in (?:the )?([^"]*) namespace`, kdt.KubeContext.MultiResourceOperationInNamespace)
```

These steps as defined would work if there were not non-namepace steps like below:

```go
kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource ([^"]*)$`, kdt.KubeContext.ResourceOperation)
kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^"]*)$`, kdt.KubeContext.MultiResourceOperation)
```

Because both these steps end with `([^"]*)$`, any string after the text resource will be accepted as an argument. So when including the namespace info in a `.feature` file, the non-namespace steps above were always used resulting in the following error:

```
Scenario: A web service is ready to be deployed  # features/comp-web-service/upgrade-compatibility.feature:14
    And I create resources in /comp-web-service/gen.yaml in default namespace # features/comp-web-service/upgrade-compatibility.feature:16
      Error: open templates/comp-web-service/gen.yaml in default namespace: no such file or directory
```

In order to use the same language as other steps while including the namespace details, a tighter regex should be used to not allow strings with whitespace. Since the arg in this step is a filepath, this should be a safe assumption that no whitespace will be passed. 

I was able to test this by creating the following steps locally with the following funcs:

```go
ctx.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^\s]+)$`, openFileSingle)
ctx.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in ([^\s]+) in (?:the )?([^"]*) namespace`, openFileMulti)
```

```go
func openFileSingle(op, path string) error {
	log.Info(op)
	_, err := ioutil.ReadFile("templates" + path)
	if err != nil {
		return err
	}
	return nil
}

func openFileMulti(op, path, ns string) error {
	log.Info(op)
	_, err := ioutil.ReadFile("templates" + path)
	if err != nil {
		return err
	}
	log.Info(ns)
	return nil
}
```

This pr changes the regex to `\S+` which [allows everything except whitespace](https://stackoverflow.com/questions/42155576/regex-match-a-string-without-having-spaces). 