### PR TITLE
feat: update resources operation

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -3,10 +3,10 @@ Below you will find the step syntax next to the name of the method it utilizes. 
 
 **Kubernetes related steps**:
 1. 	`<GK> a Kubernetes cluster` [AKubernetesCluster](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.AKubernetesCluster)
-2.	`<GK> [I] <create|submit|delete> [the] resource <filename>.yaml` [ResourceOperation](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceOperation)
-3.	`<GK> [I] <create|submit|delete> [the] resource <filename>.yaml in [the] <namespacename> namespace` [ResourceOperationInNamespace](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceOperationInNamespace)
-4.	`<GK> [I] <create|submit|delete> [the] resources in <filename>.yaml` [MultiResourceOperation](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.MultiResourceOperation)
-5.	`<GK> [I] <create|submit|delete> [the] resources in <filename>.yaml in [the] <namespacename> namespace` [MultiResourceOperationInNamespace](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.MultiResourceOperationInNamespace)
+2.	`<GK> [I] <create|submit|delete|update> [the] resource <filename>.yaml` [ResourceOperation](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceOperation)
+3.	`<GK> [I] <create|submit|delete|update> [the] resource <filename>.yaml in [the] <namespacename> namespace` [ResourceOperationInNamespace](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceOperationInNamespace)
+4.	`<GK> [I] <create|submit|delete|update> [the] resources in <filename>.yaml` [MultiResourceOperation](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.MultiResourceOperation)
+5.	`<GK> [I] <create|submit|delete|update> [the] resources in <filename>.yaml in [the] <namespacename> namespace` [MultiResourceOperationInNamespace](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.MultiResourceOperationInNamespace)
 6.	`<GK> [the] resource <filename> should be <created|deleted>` [ResourceShouldBe](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceShouldBe)
 7.	`<GK> [the] resource <filename> [should] converge(d) to selector <complete key>=<value>` [ResourceShouldConvergeToSelector](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceShouldConvergeToSelector)
 8.	`<GK> [the] resource <filename> condition <condition type> should be (true|false)` [ResourceConditionShouldBe](https://godoc.org/github.com/keikoproj/kubedog/pkg/kubernetes#Client.ResourceConditionShouldBe)

--- a/kubedog.go
+++ b/kubedog.go
@@ -48,10 +48,10 @@ func (kdt *Test) Run() {
 
 	// Kubernetes related steps
 	kdt.scenarioContext.Step(`^a Kubernetes cluster$`, kdt.KubeContext.AKubernetesCluster)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource (\S+)$`, kdt.KubeContext.ResourceOperation)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resource (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.ResourceOperationInNamespace)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in (\S+)$`, kdt.KubeContext.MultiResourceOperation)
-	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete) (?:the )?resources in (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.MultiResourceOperationInNamespace)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete|update) (?:the )?resource (\S+)$`, kdt.KubeContext.ResourceOperation)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete|update) (?:the )?resource (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.ResourceOperationInNamespace)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete|update) (?:the )?resources in (\S+)$`, kdt.KubeContext.MultiResourceOperation)
+	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete|update) (?:the )?resources in (\S+) in (?:the )?([^"]*) namespace`, kdt.KubeContext.MultiResourceOperationInNamespace)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should be (created|deleted)$`, kdt.KubeContext.ResourceShouldBe)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) converged to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)
 	kdt.scenarioContext.Step(`^(?:the )?resource ([^"]*) should converge to selector ([^"]*)$`, kdt.KubeContext.ResourceShouldConvergeToSelector)

--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -230,8 +230,8 @@ func (kc *Client) unstructuredResourceOperation(operation, ns string, unstructur
 		if err != nil {
 			return err
 		}
-		
-		resource.SetResourceVersion(currentResourceVersion.GetResourceVersion())
+
+		resource.SetResourceVersion(currentResourceVersion.DeepCopy().GetResourceVersion())
 
 		_, err = kc.DynamicInterface.Resource(gvr.Resource).Namespace(ns).Update(context.Background(), resource, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -117,7 +117,7 @@ func (kc *Client) AKubernetesCluster() error {
 }
 
 /*
-ResourceOperation performs the given operation on the resource defined in resourceFileName. The operation could be “create”, “submit” or “delete”.
+ResourceOperation performs the given operation on the resource defined in resourceFileName. The operation could be “create”, “submit”, “delete”, or "update".
 */
 func (kc *Client) ResourceOperation(operation, resourceFileName string) error {
 	unstructuredResource, err := kc.parseSingleResource(resourceFileName)
@@ -127,6 +127,9 @@ func (kc *Client) ResourceOperation(operation, resourceFileName string) error {
 	return kc.unstructuredResourceOperation(operation, "", unstructuredResource)
 }
 
+/*
+ResourceOperationInNamespace performs the given operation on the resource defined in resourceFileName in a specified namespace. The operation could be “create”, “submit”, “delete”, or "update".
+*/
 func (kc *Client) ResourceOperationInNamespace(operation, resourceFileName, ns string) error {
 	unstructuredResource, err := kc.parseSingleResource(resourceFileName)
 	if err != nil {
@@ -222,6 +225,19 @@ func (kc *Client) unstructuredResourceOperation(operation, ns string, unstructur
 			return err
 		}
 		log.Infof("%s %s has been created in namespace %s", resource.GetKind(), resource.GetName(), ns)
+	case OperationUpdate:
+		currentResourceVersion, err := kc.DynamicInterface.Resource(gvr.Resource).Namespace(ns).Get(context.Background(), resource.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		
+		resource.SetResourceVersion(currentResourceVersion.GetResourceVersion())
+
+		_, err = kc.DynamicInterface.Resource(gvr.Resource).Namespace(ns).Update(context.Background(), resource, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		log.Infof("%s %s has been updated in namespace %s", resource.GetKind(), resource.GetName(), ns)
 	case OperationDelete:
 		err := kc.DynamicInterface.Resource(gvr.Resource).Namespace(ns).Delete(context.Background(), resource.GetName(), metav1.DeleteOptions{})
 		if err != nil {

--- a/pkg/kubernetes/kube_test.go
+++ b/pkg/kubernetes/kube_test.go
@@ -594,6 +594,16 @@ func Test_unstructuredResourceOperation(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
+	resourceNoNsUpdate, err := resourceFromYaml("../../test/templates/resource-without-namespace-update.yaml")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	resourceNsUpdate, err := resourceFromYaml("../../test/templates/resource-with-namespace-update.yaml")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
 	dynScheme := runtime.NewScheme()
 	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(dynScheme)
 
@@ -614,6 +624,21 @@ func Test_unstructuredResourceOperation(t *testing.T) {
 				unstructuredResource: util.K8sUnstructuredResource{
 					GVR:      &meta.RESTMapping{},
 					Resource: resourceNoNs,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Resource update succeeds when namespace is configurable",
+			clientFields: clientFields{
+				DynamicInterface: fakeDynamicClient,
+			},
+			funcArgs: funcArgs{
+				operation: "update",
+				ns:        "test-namespace",
+				unstructuredResource: util.K8sUnstructuredResource{
+					GVR:      &meta.RESTMapping{},
+					Resource: resourceNoNsUpdate,
 				},
 			},
 			wantErr: false,
@@ -643,6 +668,20 @@ func Test_unstructuredResourceOperation(t *testing.T) {
 				unstructuredResource: util.K8sUnstructuredResource{
 					GVR:      &meta.RESTMapping{},
 					Resource: resourceNs,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Resource update succeeds when namespace is in YAML",
+			clientFields: clientFields{
+				DynamicInterface: fakeDynamicClient,
+			},
+			funcArgs: funcArgs{
+				operation: "update",
+				unstructuredResource: util.K8sUnstructuredResource{
+					GVR:      &meta.RESTMapping{},
+					Resource: resourceNsUpdate,
 				},
 			},
 			wantErr: false,

--- a/test/templates/resource-with-namespace-update.yaml
+++ b/test/templates/resource-with-namespace-update.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guestbook-ui
+  namespace: test-namespace
+spec:
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: guestbook-ui
+  template:
+    metadata:
+      labels:
+        app: guestbook-ui
+    spec:
+      containers:
+        - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+          name: guestbook-ui
+          ports:
+            - containerPort: 8

--- a/test/templates/resource-without-namespace-update.yaml
+++ b/test/templates/resource-without-namespace-update.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guestbook-ui
+spec:
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: guestbook-ui
+  template:
+    metadata:
+      labels:
+        app: guestbook-ui
+    spec:
+      containers:
+        - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+          name: guestbook-ui
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Closes #64 

This pull request adds the ability to update resources during bdd testing. This is not idempotent (i.e., resources must exist prior to updating. It also requires a Get call to k8s API to retrieve resourceVersion to set on object to be updated (for more details on this, please read in #64 why this is needed).