### PR TITLE
feat: open source Intuit testing steps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-sdk-go v1.33.8
 	github.com/cucumber/godog v0.12.5
+	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
@@ -23,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nxadm/tail v1.4.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
@@ -55,6 +58,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect

--- a/kubedog.go
+++ b/kubedog.go
@@ -73,6 +73,12 @@ func (kdt *Test) Run() {
 	kdt.scenarioContext.Step(`^(?:the )?(clusterrole|clusterrolebinding) with name ([^"]*) should be found$`, kdt.KubeContext.ClusterRbacIsFound)
 	kdt.scenarioContext.Step(`^(?:the )?ingress (\S+) in (?:the )?namespace (\S+) (?:is )?(?:available )?on port (\d+) and path ([^"]*)$`, kdt.KubeContext.IngressAvailable)
 	kdt.scenarioContext.Step(`^(?:I )?send (\d+) tps to ingress (\S+) in (?:the )?namespace (\S+) (?:available )?on port (\d+) and path ([^"]*) for (\d+) (minutes|seconds) expecting (\d+) errors$`, kdt.KubeContext.SendTrafficToIngress)
+	kdt.scenarioContext.Step(`^(?:the )?pods in namespace ([^"]*) with selector ([^"]*) has ([^"]*) in logs since ([^"]*) time and times out in (\S+) seconds`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHasThisSentenceInLogsSinceTime)
+	kdt.scenarioContext.Step(`^(?:the )?pods in namespace ([^"]*) with selector ([^"]*) doesn't have ([^"]*) in logs since ([^"]*) time$`, kdt.KubeContext.NoMatchingStringInLogsSinceTime)
+	kdt.scenarioContext.Step(`^(?:the )?pods in namespace ([^"]*) with selector ([^"]*) have no errors in logs since ([^"]*) time$`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHaveNoErrorsInLogsSinceTime)
+	kdt.scenarioContext.Step(`^(?:the )?pods in namespace ([^"]*) with selector ([^"]*) have some errors in logs since ([^"]*) time$`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHaveSomeErrorsInLogsSinceTime)
+	kdt.scenarioContext.Step(`^(?:the )?pods in namespace (\S+) with selector (\S+) should have labels (\S+)$`, kdt.KubeContext.ThePodsInNamespaceShouldHaveLabels)
+
 	// AWS related steps
 	kdt.scenarioContext.Step(`^(?:there are )?(?:valid )?AWS Credentials$`, kdt.AwsContext.GetAWSCredsAndClients)
 	kdt.scenarioContext.Step(`^an Auto Scaling Group named ([^"]*)$`, kdt.AwsContext.AnASGNamed)

--- a/kubedog.go
+++ b/kubedog.go
@@ -48,6 +48,9 @@ func (kdt *Test) Run() {
 	}
 
 	kdt.scenarioContext.Step(`^(?:I )?wait for (\d+) (minutes|seconds)$`, common.WaitFor)
+	kdt.scenarioContext.Step(`^the (\S+) command is available`, common.CommandExists)
+	kdt.scenarioContext.Step(`^I run the (\S+) command with the ([^"]*) args the command (fails|succeeds)`, common.RunCommand)
+
 	// Kubernetes related steps
 	kdt.scenarioContext.Step(`^((?:a )?Kubernetes cluster|(?:there are )?(?:valid )?Kubernetes Credentials)$`, kdt.KubeContext.KubernetesCluster)
 	kdt.scenarioContext.Step(`^(?:I )?(create|submit|delete|update) (?:the )?resource (\S+)$`, kdt.KubeContext.ResourceOperation)

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -300,3 +300,93 @@ metadata:
 		}
 	}
 }
+
+func TestCommandExists(t *testing.T) {
+	type args struct {
+		command string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Command SHOULD exist",
+			args: args{
+				command: "echo",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Command SHOULD NOT exist",
+			args: args{
+				command: "doesnotexist",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CommandExists(tt.args.command); (err != nil) != tt.wantErr {
+				t.Errorf("CommandExists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	type args struct {
+		command       string
+		args          string
+		successOrFail string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Command FAILS and is EXPECTED TO",
+			args: args{
+				command:       "doesnotexist",
+				args:          "not real",
+				successOrFail: "fails",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Command FAILS and is NOT EXPECTED TO",
+			args: args{
+				command:       "doesnotexist",
+				args:          "not real",
+				successOrFail: "succeeds",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Command SUCCEEDS and is EXPECTED TO",
+			args: args{
+				command:       "echo",
+				args:          "I want to succeed",
+				successOrFail: "succeeds",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Command SUCCEEDS and is NOT EXPECTED TO",
+			args: args{
+				command:       "echo",
+				args:          "what why would I succeed?",
+				successOrFail: "fails",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := RunCommand(tt.args.command, tt.args.args, tt.args.successOrFail); (err != nil) != tt.wantErr {
+				t.Errorf("RunCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/kube_test.go
+++ b/pkg/kubernetes/kube_test.go
@@ -38,6 +38,7 @@ import (
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
 	fakeDynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	kTesting "k8s.io/client-go/testing"
 )
@@ -51,6 +52,9 @@ func TestPositiveNodesWithSelectorShouldBe(t *testing.T) {
 		testReadyLabel    = map[string]string{"testing-ShouldBeReady": "some-value"}
 		testFoundLabel    = map[string]string{"testing-ShouldBeFound": "some-value"}
 		fakeClient        *fake.Clientset
+		dynScheme         = runtime.NewScheme()
+		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(dynScheme)
+		fakeDiscovery     = &fakeDiscovery.FakeDiscovery{}
 	)
 
 	fakeClient = fake.NewSimpleClientset(&v1.Node{
@@ -74,8 +78,10 @@ func TestPositiveNodesWithSelectorShouldBe(t *testing.T) {
 	})
 
 	kc := Client{
-		KubeInterface: fakeClient,
-		FilesPath:     "../../test/templates",
+		KubeInterface:      fakeClient,
+		DiscoveryInterface: fakeDiscovery,
+		DynamicInterface:   fakeDynamicClient,
+		FilesPath:          "../../test/templates",
 	}
 
 	err := kc.NodesWithSelectorShouldBe(1, testReadySelector, NodeStateReady)
@@ -92,6 +98,7 @@ func TestPositiveResourceOperation(t *testing.T) {
 		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(dynScheme)
 		testResource      *unstructured.Unstructured
 		fakeDiscovery     = fakeDiscovery.FakeDiscovery{}
+		fakeClient        *fake.Clientset
 	)
 
 	const fileName = "test-resourcefile.yaml"
@@ -105,6 +112,7 @@ func TestPositiveResourceOperation(t *testing.T) {
 	fakeDiscovery.Resources = append(fakeDiscovery.Resources, newTestAPIResourceList(testResource.GetAPIVersion(), testResource.GetName(), testResource.GetKind()))
 
 	kc := Client{
+		KubeInterface:      fakeClient,
 		DynamicInterface:   fakeDynamicClient,
 		DiscoveryInterface: &fakeDiscovery,
 		FilesPath:          "../../test/templates",
@@ -194,6 +202,7 @@ func TestPositiveResourceShouldBe(t *testing.T) {
 		dynScheme           = runtime.NewScheme()
 		fakeDynamicClient   = fakeDynamic.NewSimpleDynamicClient(dynScheme)
 		fakeDiscovery       = fakeDiscovery.FakeDiscovery{}
+		fakeClient          *fake.Clientset
 		testResource        *unstructured.Unstructured
 		createdReactionFunc = func(action kTesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, testResource, nil
@@ -218,6 +227,7 @@ func TestPositiveResourceShouldBe(t *testing.T) {
 	kc := Client{
 		DynamicInterface:   fakeDynamicClient,
 		DiscoveryInterface: &fakeDiscovery,
+		KubeInterface:      fakeClient,
 		FilesPath:          "../../test/templates",
 	}
 
@@ -241,6 +251,7 @@ func TestPositiveResourceShouldConvergeToSelector(t *testing.T) {
 		g                 = gomega.NewWithT(t)
 		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
 		fakeDiscovery     = fakeDiscovery.FakeDiscovery{}
+		fakeClient        *fake.Clientset
 		testResource      *unstructured.Unstructured
 		getReactionFunc   = func(action kTesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, testResource, nil
@@ -265,6 +276,7 @@ func TestPositiveResourceShouldConvergeToSelector(t *testing.T) {
 	kc := Client{
 		DynamicInterface:   fakeDynamicClient,
 		DiscoveryInterface: &fakeDiscovery,
+		KubeInterface:      fakeClient,
 		FilesPath:          "../../test/templates",
 	}
 
@@ -279,6 +291,7 @@ func TestPositiveResourceConditionShouldBe(t *testing.T) {
 		g                 = gomega.NewWithT(t)
 		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
 		fakeDiscovery     = fakeDiscovery.FakeDiscovery{}
+		fakeClient        *fake.Clientset
 		testResource      *unstructured.Unstructured
 		getReactionFunc   = func(action kTesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, testResource, nil
@@ -304,6 +317,7 @@ func TestPositiveResourceConditionShouldBe(t *testing.T) {
 	kc := Client{
 		DynamicInterface:   fakeDynamicClient,
 		DiscoveryInterface: &fakeDiscovery,
+		KubeInterface:      fakeClient,
 		FilesPath:          "../../test/templates",
 	}
 
@@ -325,6 +339,7 @@ func TestPositiveUpdateResourceWithField(t *testing.T) {
 		g                 = gomega.NewWithT(t)
 		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
 		fakeDiscovery     = fakeDiscovery.FakeDiscovery{}
+		fakeClient        *fake.Clientset
 		testResource      *unstructured.Unstructured
 		getReactionFunc   = func(action kTesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, testResource, nil
@@ -349,6 +364,7 @@ func TestPositiveUpdateResourceWithField(t *testing.T) {
 	kc := Client{
 		DynamicInterface:   fakeDynamicClient,
 		DiscoveryInterface: &fakeDiscovery,
+		KubeInterface:      fakeClient,
 		FilesPath:          "../../test/templates",
 	}
 
@@ -362,10 +378,12 @@ func TestPositiveUpdateResourceWithField(t *testing.T) {
 
 func TestResourceInNamespace(t *testing.T) {
 	var (
-		err            error
-		g              = gomega.NewWithT(t)
-		fakeKubeClient = fake.NewSimpleClientset()
-		namespace      = "test_ns"
+		err               error
+		g                 = gomega.NewWithT(t)
+		fakeKubeClient    = fake.NewSimpleClientset()
+		namespace         = "test_ns"
+		fakeDynamicClient = fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
+		fakeDiscovery     = &fakeDiscovery.FakeDiscovery{}
 	)
 
 	tests := []struct {
@@ -403,7 +421,9 @@ func TestResourceInNamespace(t *testing.T) {
 	}
 
 	kc := Client{
-		KubeInterface: fakeKubeClient,
+		KubeInterface:      fakeKubeClient,
+		DynamicInterface:   fakeDynamicClient,
+		DiscoveryInterface: fakeDiscovery,
 	}
 
 	_, _ = kc.KubeInterface.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
@@ -723,6 +743,116 @@ func Test_unstructuredResourceOperation(t *testing.T) {
 			}
 			if err := kc.unstructuredResourceOperation(tt.funcArgs.operation, tt.funcArgs.ns, tt.funcArgs.unstructuredResource); (err != nil) != tt.wantErr {
 				t.Errorf("Client.unstructuredResourceOperation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_ThePodsInNamespaceShouldHaveLabels(t *testing.T) {
+	ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	podWithLabels1 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-foo-xhhxj",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"app":   "foo",
+				"label": "true",
+			},
+		},
+	}
+	podWithLabels2 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-foo-xhhzd",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"app":   "foo",
+				"label": "true",
+			},
+		},
+	}
+	podMissingLabel := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-foo-xhhzr",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"app": "foo",
+			},
+		},
+	}
+	clientNoErr := fake.NewSimpleClientset(&ns, &podWithLabels1, &podWithLabels2)
+	clientErr := fake.NewSimpleClientset(&ns, &podWithLabels1, &podWithLabels2, &podMissingLabel)
+	dynScheme := runtime.NewScheme()
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(dynScheme)
+	fakeDiscoveryClient := fakeDiscovery.FakeDiscovery{}
+
+	type fields struct {
+		KubeInterface      kubernetes.Interface
+		DynamicInterface   dynamic.Interface
+		DiscoveryInterface *fakeDiscovery.FakeDiscovery
+	}
+	type args struct {
+		namespace string
+		selector  string
+		labels    string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "No pods found",
+			fields: fields{
+				KubeInterface:      clientErr,
+				DiscoveryInterface: &fakeDiscoveryClient,
+				DynamicInterface:   fakeDynamicClient,
+			},
+			args: args{
+				selector:  "app=doesnotexist",
+				namespace: "foo",
+				labels:    "app=foo,label=true",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Pods should have labels",
+			fields: fields{
+				KubeInterface:      clientNoErr,
+				DiscoveryInterface: &fakeDiscoveryClient,
+				DynamicInterface:   fakeDynamicClient,
+			},
+			args: args{
+				selector:  "app=foo",
+				namespace: "foo",
+				labels:    "app=foo,label=true",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error from pod missing label",
+			fields: fields{
+				KubeInterface:      clientErr,
+				DiscoveryInterface: &fakeDiscoveryClient,
+				DynamicInterface:   fakeDynamicClient,
+			},
+			args: args{
+				selector:  "app=foo",
+				namespace: "foo",
+				labels:    "app=foo,label=true",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kc := &Client{
+				KubeInterface:      tt.fields.KubeInterface,
+				DynamicInterface:   tt.fields.DynamicInterface,
+				DiscoveryInterface: tt.fields.DiscoveryInterface,
+			}
+			if err := kc.ThePodsInNamespaceShouldHaveLabels(tt.args.namespace, tt.args.selector, tt.args.labels); (err != nil) != tt.wantErr {
+				t.Errorf("ThePodsInNamespaceShouldHaveLabels() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Some of the pod logs steps are difficult to cover with unit tests due to not having way to mock pod logs. If we would like to consider adding e2e tests for kubedog in future, might be a good coverage approach.

Will add docs if changes look good

Steps added:

```
kdt.scenarioContext.Step(`^the pods in namespace ([^"]*) with selector ([^"]*) has ([^"]*) in logs since ([^"]*) time and times out in (\S+) seconds`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHasThisSentenceInLogsSinceTime)
	kdt.scenarioContext.Step(`^the pods in namespace ([^"]*) with selector ([^"]*) doesn't have ([^"]*) in logs since ([^"]*) time$`, kdt.KubeContext.NoMatchingStringInLogsSinceTime)
	kdt.scenarioContext.Step(`^the pods in namespace ([^"]*) with selector ([^"]*) have no errors in logs since ([^"]*) time$`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHaveNoErrorsInLogsSinceTime)
	kdt.scenarioContext.Step(`^the pods in namespace ([^"]*) with selector ([^"]*) have some errors in logs since ([^"]*) time$`, kdt.KubeContext.ThePodsInNamespaceWithSelectorHaveSomeErrorsInLogsSinceTime)
	kdt.scenarioContext.Step(`^the pod ([^"]*) in namespace ([^"]*) should have labels ([^"]*)$`, kdt.KubeContext.ThePodInNamespaceShouldHaveLabels)
```