### PR TITLE
divide DeleteResourcesAtPath() function into two for more flexibility

### DIFF
--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package kube provides steps implementations related to Kubernetes.
+// Package kube provides steps implementations related to Kubernetes.
 package kube
 
 import (
@@ -547,10 +547,18 @@ func (kc *Client) UpdateResourceWithField(resourceFileName, key string, value st
 }
 
 /*
-DeleteAllTestResources deletes all the resources defined by yaml files in the path given by FilesPath, if FilesPath is empty, it will look for the files in ./templates. Meant to be use in the before/after suite/scenario/step hooks
+DeleteAllTestResources deletes all the resources defined by yaml files in the path given by FilesPath: if FilesPath is empty, it will look for the files in ./templates. Meant to be use in the before/after suite/scenario/step hooks
 */
 func (kc *Client) DeleteAllTestResources() error {
 	resourcesPath := kc.getTemplatesPath()
+
+	return kc.DeleteResourcesAtPath(resourcesPath)
+}
+
+/*
+DeleteResourcesAtPath deletes all the resources defined by yaml files in the path provided
+*/
+func (kc *Client) DeleteResourcesAtPath(resourcesPath string) error {
 
 	// Getting context
 	err := kc.AKubernetesCluster()


### PR DESCRIPTION
Signed-off-by: Julie Vogelmani <julie_vogelman@intuit.com>

My motivation for this is I'd like to have a set of resources that I verify exist that are deployed by the addon. I've added two subdirectories: `templates/deployedbyaddon` and `templates/deployedbytest`. Now I can verify resources in `templates/deployedbyaddon` but only delete the resources in `templates/deployedbytest`.