### PR TITLE
fix checkResourceNotInNamespace

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -273,8 +273,8 @@ func (kc *ClientSet) NodesWithSelectorShouldBe(expectedNodes int, selector, stat
 	return structured.NodesWithSelectorShouldBe(kc.KubeInterface, kc.getWaiterConfig(), expectedNodes, selector, state)
 }
 
-func (kc *ClientSet) ResourceInNamespace(resourceType, name, namespace, isOrIsNot string) error {
-	return structured.ResourceInNamespace(kc.KubeInterface, resourceType, name, namespace, isOrIsNot)
+func (kc *ClientSet) ResourceInNamespace(resourceType, name, isOrIsNot, namespace string) error {
+	return structured.ResourceInNamespace(kc.KubeInterface, resourceType, name, isOrIsNot, namespace)
 }
 
 func (kc *ClientSet) ScaleDeployment(name, namespace string, replicas int32) error {

--- a/pkg/kube/structured/structured.go
+++ b/pkg/kube/structured/structured.go
@@ -377,7 +377,7 @@ func SendTrafficToIngress(kubeClientset kubernetes.Interface, w common.WaiterCon
 	return nil
 }
 
-func ResourceInNamespace(kubeClientset kubernetes.Interface, resourceType, name, namespace, isOrIsNot string) error {
+func ResourceInNamespace(kubeClientset kubernetes.Interface, resourceType, name, isOrIsNot, namespace string) error {
 	var err error
 
 	if err := common.ValidateClientset(kubeClientset); err != nil {
@@ -415,6 +415,6 @@ func ResourceInNamespace(kubeClientset kubernetes.Interface, resourceType, name,
 			return err
 		}
 	} else {
-		return errors.Errorf("paramter isOrIsNot can only be 'is' or 'is not'")
+		return errors.Errorf("parameter isOrIsNot can only be 'is' or 'is not'")
 	}
 }

--- a/pkg/kube/structured/structured_test.go
+++ b/pkg/kube/structured/structured_test.go
@@ -159,7 +159,7 @@ func TestResourceInNamespace(t *testing.T) {
 				}
 			}
 
-			err = ResourceInNamespace(fakeClient, tt.resource, tt.name, namespace, tt.isOrIsNot)
+			err = ResourceInNamespace(fakeClient, tt.resource, tt.name, tt.isOrIsNot, namespace)
 			g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 	}


### PR DESCRIPTION
During [ipa-addon-bdd testing ](https://build.intuit.com/iks/blue/organizations/jenkins/ipa-addon-bdd/detail/ipa-addon-bdd/117/pipeline) ran into Error: ```parameter isOrIsNot can only be 'is' or 'is not'``` because isOrIsNot variable was being set to the namespace 

Fix: switch order of namespace and isOrIsNot parameters