### PR TITLE
feat: always log stdout from command

### DIFF
--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -78,6 +78,10 @@ func RunCommand(command string, args, successOrFail string) error {
 	cmdStr := toRun.String()
 	log.Infof("Running command: %s", cmdStr)
 	err := toRun.Run()
+	if len(stdout.String()) > 0 {
+		log.Infof("Logging stdout from command: %s", stdout.String())
+	}
+
 	if successOrFail == "succeeds" && err != nil {
 		return fmt.Errorf("command '%s' did not succeed. error: '%v'. stderr: '%s'", cmdStr, err, stderr.String())
 	}


### PR DESCRIPTION
In scenarios when trying to debug tests that utilize a binary, it can be helpful to see all the output of the command. We should always show it regardless of success or failure of this step.