### PR TITLE
feat: add `converge to field` step which improves upon `converge to selector`

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -20,6 +20,7 @@ Below you will find the step syntax next to the name of the method it utilizes. 
 - `<GK> [I] (create|submit|delete|update|upsert) [the] resource <non-whitespace-characters> in [the] <any-characters-except-(")> namespace, the operation should (succeed|fail)` kdt.KubeClientSet.ResourceOperationWithResultInNamespace
 - `<GK> [the] resource <any-characters-except-(")> should be (created|deleted)` kdt.KubeClientSet.ResourceShouldBe
 - `<GK> [the] resource <non-whitespace-characters> [should] converge to selector <non-whitespace-characters>` kdt.KubeClientSet.ResourceShouldConvergeToSelector
+- `<GK> [the] resource <non-whitespace-characters> [should] converge to field <non-whitespace-characters>` kdt.KubeClientSet.ResourceShouldConvergeToField
 - `<GK> [the] resource <any-characters-except-(")> condition <any-characters-except-(")> should be <any-characters-except-(")>` kdt.KubeClientSet.ResourceConditionShouldBe
 - `<GK> [I] update [the] resource <any-characters-except-(")> with <any-characters-except-(")> set to <any-characters-except-(")>` kdt.KubeClientSet.UpdateResourceWithField
 - `<GK> [I] verify InstanceGroups [are] in "ready" state` kdt.KubeClientSet.VerifyInstanceGroups

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -149,8 +149,14 @@ func ExtractField(data any, path []string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		arr := data.(map[string]any)[maybeArr[0]].([]any)
-		return ExtractField(arr[i], path[1:])
+
+		dataAtIdx := data.(map[string]any)[maybeArr[0]]
+		switch dataAtIdx := dataAtIdx.(type) {
+		case []interface{}:
+			return ExtractField(dataAtIdx[i], path[1:])
+		default:
+			return ExtractField(dataAtIdx.([]map[string]any)[i], path[1:])
+		}
 	}
 
 	for key, val := range data.(map[string]any) {
@@ -159,5 +165,5 @@ func ExtractField(data any, path []string) (any, error) {
 		}
 	}
 
-	return nil, nil
+	return nil, errors.New("field not found")
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,85 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+var (
+	sampleResource = map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"containers": []map[string]any{
+					{
+						"name":    "someContainer",
+						"image":   "someImage",
+						"version": 1.4,
+						"ports": []map[string]any{
+							{"containerPort": 8080},
+							{"containerPort": 8940},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestExtractField(t *testing.T) {
+	type args struct {
+		data          any
+		path          []string
+		expectedValue any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Positive Test",
+			args: args{
+				data:          sampleResource,
+				path:          []string{"spec", "template", "containers[0]", "name"},
+				expectedValue: "someContainer",
+			},
+		},
+		{
+			name: "Positive Test - multiple array",
+			args: args{
+				data:          sampleResource,
+				path:          []string{"spec", "template", "containers[0]", "ports[1]", "containerPort"},
+				expectedValue: 8940,
+			},
+		},
+		{
+			name: "Negative Test",
+			args: args{
+				data:          sampleResource,
+				path:          []string{"spec", "path", "doesnt", "exist"},
+				expectedValue: nil,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if extractedValue, err := ExtractField(tt.args.data, tt.args.path); (err != nil) != tt.wantErr || extractedValue != tt.args.expectedValue {
+				t.Errorf("ExtractField() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/kubedog.go
+++ b/kubedog.go
@@ -53,6 +53,7 @@ func (kdt *Test) SetScenario(scenario *godog.ScenarioContext) {
 	kdt.scenario.Step(`^(?:I )?(create|submit|delete|update|upsert) (?:the )?resource (\S+) in (?:the )?([^"]*) namespace, the operation should (succeed|fail)$`, kdt.KubeClientSet.ResourceOperationWithResultInNamespace)
 	kdt.scenario.Step(`^(?:the )?resource ([^"]*) should be (created|deleted)$`, kdt.KubeClientSet.ResourceShouldBe)
 	kdt.scenario.Step(`^(?:the )?resource (\S+) (?:should )?converge to selector (\S+)$`, kdt.KubeClientSet.ResourceShouldConvergeToSelector)
+	kdt.scenario.Step(`^(?:the )?resource (\S+) (?:should )?converge to field (\S+)$`, kdt.KubeClientSet.ResourceShouldConvergeToField)
 	kdt.scenario.Step(`^(?:the )?resource ([^"]*) condition ([^"]*) should be ([^"]*)$`, kdt.KubeClientSet.ResourceConditionShouldBe)
 	kdt.scenario.Step(`^(?:I )?update (?:the )?resource ([^"]*) with ([^"]*) set to ([^"]*)$`, kdt.KubeClientSet.UpdateResourceWithField)
 	kdt.scenario.Step(`^(?:I )?verify InstanceGroups (?:are )?in "ready" state$`, kdt.KubeClientSet.VerifyInstanceGroups)

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -190,6 +190,14 @@ func (kc *ClientSet) ResourceShouldConvergeToSelector(resourceFileName, selector
 	return unstruct.ResourceShouldConvergeToSelector(kc.DynamicInterface, resource, kc.getWaiterConfig(), selector)
 }
 
+func (kc *ClientSet) ResourceShouldConvergeToField(resourceFileName, selector string) error {
+	resource, err := unstruct.GetResource(kc.getDiscoveryClient(), kc.config.templateArguments, kc.getResourcePath(resourceFileName))
+	if err != nil {
+		return err
+	}
+	return unstruct.ResourceShouldConvergeToField(kc.DynamicInterface, resource, kc.getWaiterConfig(), selector)
+}
+
 func (kc *ClientSet) ResourceConditionShouldBe(resourceFileName, conditionType, conditionValue string) error {
 	resource, err := unstruct.GetResource(kc.getDiscoveryClient(), kc.config.templateArguments, kc.getResourcePath(resourceFileName))
 	if err != nil {

--- a/pkg/kube/unstructured/test/files/resource.yaml
+++ b/pkg/kube/unstructured/test/files/resource.yaml
@@ -16,3 +16,6 @@ spec:
     - name: someContainer
       image: someImage
       version: 1.0.0
+      ports:
+      - containerPort: 8080
+      - containerPort: 8940

--- a/pkg/kube/unstructured/test/files/resource.yaml
+++ b/pkg/kube/unstructured/test/files/resource.yaml
@@ -13,6 +13,6 @@ status:
 spec:
   template:
     containers:
-    - name: "test"
-      image: "test-image"
+    - name: someContainer
+      image: someImage
       version: 1.0.0

--- a/pkg/kube/unstructured/test/files/resource.yaml
+++ b/pkg/kube/unstructured/test/files/resource.yaml
@@ -9,3 +9,10 @@ status:
   conditions:
     - type: someConditionType
       status: "True"
+  replicaCount: 2
+spec:
+  template:
+    containers:
+    - name: "test"
+      image: "test-image"
+      version: 1.0.0

--- a/pkg/kube/unstructured/unstructured.go
+++ b/pkg/kube/unstructured/unstructured.go
@@ -196,7 +196,7 @@ func ResourceShouldBe(dynamicClient dynamic.Interface, resource unstructuredReso
 	}
 }
 
-func ResourceShouldConvergeToSelector(dynamicClient dynamic.Interface, resource unstructuredResource, w common.WaiterConfig, selector string) error {
+func ResourceShouldConvergeToField(dynamicClient dynamic.Interface, resource unstructuredResource, w common.WaiterConfig, selector string) error {
 	var counter int
 
 	if err := validateDynamicClient(dynamicClient); err != nil {
@@ -254,7 +254,7 @@ func ResourceShouldConvergeToSelector(dynamicClient dynamic.Interface, resource 
 	return nil
 }
 
-func ResourceShouldConvergeToField(dynamicClient dynamic.Interface, resource unstructuredResource, w common.WaiterConfig, selector string) error {
+func ResourceShouldConvergeToSelector(dynamicClient dynamic.Interface, resource unstructuredResource, w common.WaiterConfig, selector string) error {
 	var counter int
 
 	if err := validateDynamicClient(dynamicClient); err != nil {

--- a/pkg/kube/unstructured/unstructured_test.go
+++ b/pkg/kube/unstructured/unstructured_test.go
@@ -566,6 +566,14 @@ func TestResourceShouldConvergeToField(t *testing.T) {
 			},
 		},
 		{
+			name: "Positive Test: array of array",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".spec.template.containers[0].ports[1].containerPort=8940",
+			},
+		},
+		{
 			name: "Negative Test: invalid selector",
 			args: args{
 				dynamicClient: newFakeDynamicClientWithResource(resource),

--- a/pkg/kube/unstructured/unstructured_test.go
+++ b/pkg/kube/unstructured/unstructured_test.go
@@ -457,6 +457,30 @@ func TestResourceShouldConvergeToSelector(t *testing.T) {
 			},
 		},
 		{
+			name: "Positive Test: array",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".spec.template.containers[0].image=test-image",
+			},
+		},
+		{
+			name: "Positive Test: non-string value",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".status.replicaCount=2",
+			},
+		},
+		{
+			name: "Positive Test: array and non-string value",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".spec.template.containers[0].version=1.0.0",
+			},
+		},
+		{
 			name: "Negative Test: invalid client",
 			args: args{
 				dynamicClient: nil,

--- a/pkg/kube/unstructured/unstructured_test.go
+++ b/pkg/kube/unstructured/unstructured_test.go
@@ -546,7 +546,7 @@ func TestResourceShouldConvergeToField(t *testing.T) {
 			args: args{
 				dynamicClient: newFakeDynamicClientWithResource(resource),
 				resource:      resource,
-				selector:      ".spec.template.containers[0].image=test-image",
+				selector:      ".spec.template.containers[0].image=someImage",
 			},
 		},
 		{

--- a/pkg/kube/unstructured/unstructured_test.go
+++ b/pkg/kube/unstructured/unstructured_test.go
@@ -457,30 +457,6 @@ func TestResourceShouldConvergeToSelector(t *testing.T) {
 			},
 		},
 		{
-			name: "Positive Test: array",
-			args: args{
-				dynamicClient: newFakeDynamicClientWithResource(resource),
-				resource:      resource,
-				selector:      ".spec.template.containers[0].image=test-image",
-			},
-		},
-		{
-			name: "Positive Test: non-string value",
-			args: args{
-				dynamicClient: newFakeDynamicClientWithResource(resource),
-				resource:      resource,
-				selector:      ".status.replicaCount=2",
-			},
-		},
-		{
-			name: "Positive Test: array and non-string value",
-			args: args{
-				dynamicClient: newFakeDynamicClientWithResource(resource),
-				resource:      resource,
-				selector:      ".spec.template.containers[0].version=1.0.0",
-			},
-		},
-		{
 			name: "Negative Test: invalid client",
 			args: args{
 				dynamicClient: nil,
@@ -537,6 +513,81 @@ func TestResourceShouldConvergeToSelector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.w = common.NewWaiterConfig(1, time.Second)
 			if err := ResourceShouldConvergeToSelector(tt.args.dynamicClient, tt.args.resource, tt.args.w, tt.args.selector); (err != nil) != tt.wantErr {
+				t.Errorf("ResourceShouldConvergeToSelector() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResourceShouldConvergeToField(t *testing.T) {
+	type args struct {
+		dynamicClient dynamic.Interface
+		resource      unstructuredResource
+		w             common.WaiterConfig
+		selector      string
+	}
+	resource := getResourceFromYaml(t, getFilePath("resource.yaml"))
+	labelKey, labelValue := getOneLabel(t, *resource.Resource)
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Positive Test",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".metadata.labels." + labelKey + "=" + labelValue,
+			},
+		},
+		{
+			name: "Positive Test: array",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".spec.template.containers[0].image=test-image",
+			},
+		},
+		{
+			name: "Positive Test: non-string value",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".status.replicaCount=2",
+			},
+		},
+		{
+			name: "Positive Test: array and non-string value",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".spec.template.containers[0].version=1.0.0",
+			},
+		},
+		{
+			name: "Negative Test: invalid selector",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".invalid.selector.",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Negative Test: invalid key",
+			args: args{
+				dynamicClient: newFakeDynamicClientWithResource(resource),
+				resource:      resource,
+				selector:      ".=invalid-key",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.w = common.NewWaiterConfig(1, time.Second)
+			if err := ResourceShouldConvergeToField(tt.args.dynamicClient, tt.args.resource, tt.args.w, tt.args.selector); (err != nil) != tt.wantErr {
 				t.Errorf("ResourceShouldConvergeToSelector() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Currently the `converge to selector` syntax for a step in a feature file does not accommodate for two cases that came up in our testing:
- if the selector contains an array (ie. containers[0].image) it will not be able to traverse this path to check the value
- if the value of a selector's path is not a string, the value will not be checked properly (ie. replicaCount=2 will fail since 2 is considered a string when passed as part of the `key=value` selector)

This pull requests adds support for both of these cases by incorporating a new step: `ResourceShouldConvergeToField`

For managing arrays in a path, I was able to work with a colleague @afugazzotto who has previously added a similar function to the [Numaplane](https://github.com/numaproj/numaplane) open source project. 

Here is [the function](https://github.com/numaproj/numaplane/blob/cdd087570e308e1508986b2911bf11bd909cd748/internal/util/util.go#L139-L187) that the solution in this pull request is based on which is used in Numaplane to get the full path to a field in a Kubernetes resource. 

The function takes `data` as the resource and `path` as the `key` value of our selector which is a path to our field we want to check. It recurses after moving down each field of the path and to accommodate for arrays, we check if the current field contains the `[` character which tells us that it is an array. After doing so, we can isolate the index value and recurse on the array[index] value. There are new unit test cases created for the new `ResourceShouldConvergeToField` function test to show this new functionality.

```
func ExtractField(data any, path []string) (any, error) {
	if len(path) == 0 || data == nil {
		return data, nil
	}

	currKey := path[0]

	maybeArr := strings.Split(currKey, "[")
	if len(maybeArr) >= 2 {
		indexStr := strings.TrimSuffix(maybeArr[1], "]")
		i, err := strconv.Atoi(indexStr)
		if err != nil {
			return nil, err
		}
		arr := data.(map[string]any)[maybeArr[0]].([]any)
		return ExtractField(arr[i], path[1:])
	}

	for key, val := range data.(map[string]any) {
		if key == currKey {
			return ExtractField(val, path[1:])
		}
	}

	return nil, nil
}
```

After getting the value from `ExtractField`, we need to check what type it is to accurately check it against a string or integer. 
Once we know the type of the returned value, we will convert our value from the selector to an integer if needed or continue as a string.

```
var convertedValue any
switch val.(type) {
case int, int64:
	convertedValue, err = strconv.ParseInt(value, 10, 64)
	if err != nil {
		return err
	}
case string:
	convertedValue = value
```