### PR TITLE
fix: retry discovery/REST-mapping on transient errors like EOF

### DIFF
--- a/pkg/kube/unstructured/unstructured_helper.go
+++ b/pkg/kube/unstructured/unstructured_helper.go
@@ -139,11 +139,21 @@ func getGVR(gvk *schema.GroupVersionKind, dc discovery.DiscoveryInterface) (*met
 		return nil, errors.Errorf("'k8s.io/client-go/discovery.DiscoveryInterface' is nil.")
 	}
 
-	CachedDiscoveryInterface := memory.NewMemCacheClient(dc)
-	DeferredDiscoveryRESTMapper := restmapper.NewDeferredDiscoveryRESTMapper(CachedDiscoveryInterface)
-	RESTMapping, err := DeferredDiscoveryRESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	// The REST mapping triggers discovery calls (e.g. GET /api, /apis) that can
+	// hit transient failures like EOF, so retry it the same way as resource ops.
+	// The cache and mapper are rebuilt each attempt to avoid reusing a partially
+	// populated discovery cache from a failed attempt.
+	result, err := util.RetryOnError(&util.DefaultRetry, util.IsRetriable, func() (interface{}, error) {
+		CachedDiscoveryInterface := memory.NewMemCacheClient(dc)
+		DeferredDiscoveryRESTMapper := restmapper.NewDeferredDiscoveryRESTMapper(CachedDiscoveryInterface)
+		return DeferredDiscoveryRESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	})
 	if err != nil {
 		return nil, err
+	}
+	RESTMapping, ok := result.(*meta.RESTMapping)
+	if !ok {
+		return nil, errors.Errorf("failed to get REST mapping: unexpected type '%T'", result)
 	}
 	return RESTMapping, nil
 }


### PR DESCRIPTION
## Summary
- `getGVR` resolves a resource's GVR via the deferred discovery REST mapper, which issues discovery calls (`GET /api`, `/apis`). These were not wrapped in the retry helper used by the actual resource operations, so a transient failure like `Get ".../api": EOF` failed the step immediately — even though `EOF` is already classified as retriable by `util.IsRetriable`.
- Wrap the `RESTMapping` call in `util.RetryOnError(&util.DefaultRetry, util.IsRetriable, ...)`, rebuilding the mem cache client and deferred mapper on each attempt so a partially populated discovery cache from a failed attempt is not reused.
- Closes the gap left by #175, which added retries to the resource operations but not to the GVR/discovery resolution that precedes them.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/kube/unstructured/`
- [x] `go test ./pkg/kube/unstructured/ ./pkg/util/`
- [ ] Reviewer: confirm a transient EOF during `create resource <file>` is now retried