### PR TITLE
fix: tolerate transient errors in NodesWithSelectorShouldBe waiter

### DIFF
--- a/pkg/kube/structured/structured.go
+++ b/pkg/kube/structured/structured.go
@@ -64,6 +64,15 @@ func NodesWithSelectorShouldBe(kubeClientset kubernetes.Interface, w common.Wait
 			return kubeClientset.CoreV1().Nodes().List(context.Background(), opts)
 		})
 		if err != nil {
+			// The inner RetryOnError only smooths over brief API blips (~6s).
+			// If a transient/retriable error (e.g. EOF) outlasts it, let the
+			// outer waiter loop absorb it instead of failing the whole step.
+			if util.IsRetriable(err) {
+				log.Warnf("transient error listing nodes with selector %v, will retry: %v", labelSelector, err)
+				counter++
+				time.Sleep(w.GetInterval())
+				continue
+			}
 			return errors.Wrap(err, "failed to list nodes")
 		}
 		nodes, ok := nodeList.(*corev1.NodeList)


### PR DESCRIPTION
The node List call is wrapped in util.RetryOnError(DefaultRetry), which only smooths over ~6s of API blips. When a transient/retriable error such as `Get ".../api/v1/nodes?labelSelector=...": EOF` outlasted that inner retry, the step failed immediately via a hard return, bypassing the outer waiter loop that was designed to wait up to w.GetTries() * w.GetInterval().

On a retriable error, log and continue the outer waiter loop (increment counter and sleep one interval) instead of returning. Non-retriable errors still fail fast, and the step still times out predictably via the existing "waiter timed out waiting for nodes" path.